### PR TITLE
Minor changes so that the dezi-config parameter will work.

### DIFF
--- a/bin/dezi
+++ b/bin/dezi
@@ -18,8 +18,8 @@ require Getopt::Long;
 Getopt::Long::Configure( "no_ignore_case", "no_auto_abbrev", "pass_through" );
 Getopt::Long::GetOptions(
     "preload-app"  => \$preload_app,
-    "dezi-config"  => \$dezi_config_file,
-    "server-class" => \$server_class,
+    "dezi-config=s"  => \$dezi_config_file,
+    "server-class=s" => \$server_class,
 );
 
 my @args = (
@@ -33,7 +33,7 @@ if ( !$preload_app ) {
 my $config = {};
 if ($dezi_config_file) {
     require Config::Any;
-    $config = Config::Any->load_files( { files => [$dezi_config_file] } );
+    $config = Config::Any->load_files( { files => [$dezi_config_file], use_ext => 1 })->[0]->{$dezi_config_file};
 }
 
 eval "use $server_class";


### PR DESCRIPTION
1. Modified Getopt::Long::GetOptions dezi-config and server-class to accept
   string values.
2. If a dezi-config value is set, we now pop that off of what Config::Any
   returns so that Dezi::Server masks the values correctly.

Three were changes that we discussed on IRC. I'm open to better ways to handling issue #2 - feel free to change.
