### PR TITLE
Pontential Security Fix

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ requires 'Search::OpenSearch::Engine::Lucy' => 0.05;
 requires 'Search::OpenSearch::Server'       => 0.09;
 requires 'Search::OpenSearch'               => 0.15;
 requires 'Plack'                            => 0;
+requires 'Module::Load'                     => 0.22;
 
 perl_version '5.8.3';
 license 'http://dev.perl.org/licenses/';

--- a/bin/dezi
+++ b/bin/dezi
@@ -3,6 +3,7 @@
 use warnings;
 use strict;
 use Plack::Runner;
+use Module::Load;
 
 our $VERSION = '0.001002';
 
@@ -33,7 +34,7 @@ if ( !$preload_app ) {
     push @args, 'loader' => 'Delayed';
 }
 
-eval "use $server_class";
+eval { load $server_class };
 die $@ if $@;
 
 my $config = {};


### PR DESCRIPTION
Suggest using Module::Load when dynamically requiring modules, could be a
potential security risk. See note on Module::Load CHANGES file (v0.22):
https://metacpan.org/source/BINGOS/Module-Load-0.22/CHANGES
