### PR TITLE
amend license to fix cpants error with metric meta_yml_conforms_to_known_spec

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ requires 'Plack::Middleware::Auth::Basic'   => 0;
 recommends 'LucyX::Suggester' => '0.003';
 
 perl_version '5.8.3';
-license 'http://dev.perl.org/licenses/';
+license 'perl';
 homepage 'https://github.com/karpet/Dezi';
 bugtracker 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dezi';
 repository 'http://github.com/karpet/Dezi';


### PR DESCRIPTION
Hi

I was assigned this module as part of Neil Bowers Pull Request Challenge.
Unfortunately I have had no time to spend on it this month, so this is a very tiny pull request to fix the cpants error:

meta_yml_conforms_to_known_spec
Take a look at the META.yml Spec at http://module-build.sourceforge.net/META-spec-v1.4.html (for version 1.4) or http://search.cpan.org/perldoc?CPAN::Meta::Spec (for version 2), and change your META.yml accordingly.

Error: License 'http://dev.perl.org/licenses/' is invalid (license) [Validation: 1.4]

See http://cpants.cpanauthors.org/dist/Dezi

Regards
Lisa